### PR TITLE
replace window.load with DOMContentLoaded

### DIFF
--- a/public/js/wp-night-mode-public.js
+++ b/public/js/wp-night-mode-public.js
@@ -21,11 +21,11 @@
 	};
 
 	// Call Functions
-	window.onload = function () {
+	document.addEventListener("DOMContentLoaded", function(event) {
 		// wp_night_mode_turn_on_time();
 		wp_night_mode_element_to_button();
 		wp_night_mode_button_click();
-	};
+	});
 
 	// Functions
 	function wp_night_mode_turn_on_time() {


### PR DESCRIPTION
Night mode toggle button is rendered only when page is fully loaded because of `window.load`. WP has lots of scripts that delay page loading. To solve this `DOMContentLoaded` should be used which is fired when HTML is parsed thus allowing to render the toggle almost immediately.